### PR TITLE
Set query params from store or initialize store from query params on settings view

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,4 +33,26 @@ const router = new VueRouter({
   ],
 });
 
+// Capure NavigationDuplicated errors caused by query parameters updates
+// https://stackoverflow.com/a/63263736
+const originalPush = router.replace;
+router.replace = function replace(location, onResolve, onReject) {
+  if (onResolve || onReject) {
+    return originalPush.call(this, location, onResolve, onReject);
+  }
+
+  return originalPush.call(this, location).catch((err) => {
+    if (
+      VueRouter.isNavigationFailure(
+        err,
+        VueRouter.NavigationFailureType.duplicated
+      )
+    ) {
+      return err;
+    }
+
+    return Promise.reject(err);
+  });
+};
+
 export default router;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,6 +12,15 @@ export default new Vuex.Store({
     wmsAdministrativeBoundariesLayer: null,
     selectedFeature: null,
   },
+  getters: {
+    isEmpty(state) {
+      return (
+        state.mangroveLayers.length === 0 &&
+        !state.administrativeBoundariesLayer &&
+        !state.selectedFeature
+      );
+    },
+  },
   mutations: {
     SET_MANGROVE_LAYERS(state, { layers }) {
       state.mangroveLayers = layers;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -30,6 +30,11 @@
 </template>
 
 <script>
+import { mapActions, mapGetters, mapState } from "vuex";
+import router from "@/router";
+import mangroveLayers from "@/data/mangrove-layers";
+import administrativeBoundariesLayers from "@/data/administrative-boundaries-layers";
+
 export default {
   data: () => ({
     drawer: false,
@@ -42,5 +47,76 @@ export default {
       },
     ],
   }),
+  computed: {
+    ...mapState([
+      "mangroveLayers",
+      "administrativeBoundariesLayer",
+      "selectedFeature",
+    ]),
+    ...mapGetters({
+      storeIsEmpty: "isEmpty",
+    }),
+    mangroveLayersIds() {
+      return this.mangroveLayers.map((layer) => layer.id).join(",");
+    },
+    selectedFeatureName() {
+      return this.selectedFeature?.properties[
+        this.administrativeBoundariesLayer?.propertyName
+      ];
+    },
+    queryParamsFromStore() {
+      return {
+        selected_feature: this.selectedFeatureName,
+        layers: this.mangroveLayersIds,
+        feature_type: this.administrativeBoundariesLayer?.id,
+      };
+    },
+  },
+  methods: {
+    ...mapActions([
+      "setMangroveLayers",
+      "setAdministrativeBoundariesLayer",
+      "setSelectedFeature",
+    ]),
+    initializeStore() {
+      const { layers, feature_type, selected_feature } = this.$route.query;
+
+      if (layers) {
+        const layerIds = (layers || "").split(",");
+        const selectedLayers = mangroveLayers.filter((layer) =>
+          layerIds.includes(layer.id)
+        );
+        this.setMangroveLayers({ layers: selectedLayers });
+      }
+
+      const selectedAdministrativeLayer = administrativeBoundariesLayers.find(
+        (layer) => layer.id === feature_type
+      );
+      if (selectedAdministrativeLayer) {
+        this.setAdministrativeBoundariesLayer({
+          layer: selectedAdministrativeLayer,
+        });
+      }
+
+      if (selectedAdministrativeLayer && selected_feature) {
+        const selectedFeature = {
+          properties: {
+            [selectedAdministrativeLayer.propertyName]: selected_feature,
+          },
+        };
+        this.setSelectedFeature({ selectedFeature });
+      }
+    },
+  },
+  beforeUpdate() {
+    router.replace({ query: this.queryParamsFromStore });
+  },
+  beforeMount() {
+    if (this.storeIsEmpty) {
+      this.initializeStore();
+    } else {
+      router.replace({ query: this.queryParamsFromStore });
+    }
+  },
 };
 </script>


### PR DESCRIPTION
Ticket: [IDPMR-13](https://issuetracker.deltares.nl/browse/IDPMR-13)

**Main features**
- Query parameters get set every time the settings view is mounted using the information on the store
- Or if the store is empty, the store gets initialized using the information on the query parameters

**TODO**
- Query parameters get updated when the user changes the visible mangrove layers or it's order
- Query parameters get updated when the user changes the administrative boundary type
- Query parameters get updated when the user changes the selected administrative boundary