### PR TITLE
Move layer list into map

### DIFF
--- a/src/components/AppMap/AppMap.vue
+++ b/src/components/AppMap/AppMap.vue
@@ -35,6 +35,12 @@
     </v-mapbox>
 
     <v-fade-transition mode="out-in">
+      <map-layers>
+        <slot name="layers-panel" />
+      </map-layers>
+    </v-fade-transition>
+
+    <v-fade-transition mode="out-in">
       <map-legend />
     </v-fade-transition>
   </div>
@@ -42,16 +48,18 @@
 
 <script>
 import { mapState } from "vuex";
-import MapControlFitbounds from "@/components/MapboxMap/MapControlFitbounds.vue";
-import MapLegend from "@/components/MapboxMap/MapLegend.vue";
-import MapDrawControl from "@/components/MapboxMap/MapDrawControl.vue";
 import { bbox } from "@turf/turf";
+import MapLegend from "@/components/MapboxMap/MapLegend.vue";
+import MapControlFitbounds from "@/components/MapboxMap/MapControlFitbounds.vue";
+import MapDrawControl from "@/components/MapboxMap/MapDrawControl.vue";
+import MapLayers from "@/components/MapboxMap/MapLayers.vue";
 
 export default {
   components: {
     MapControlFitbounds,
     MapLegend,
     MapDrawControl,
+    MapLayers,
   },
 
   data() {
@@ -106,7 +114,6 @@ export default {
 .app-map {
   overflow: hidden;
   position: relative;
-  min-height: 400px;
 }
 
 .app-map,

--- a/src/components/DashboardLayout/DashboardLayout.vue
+++ b/src/components/DashboardLayout/DashboardLayout.vue
@@ -4,10 +4,10 @@
       <v-row>
         <v-col cols="12" :md="6" :lg="4">
           <v-card class="pa-4 mb-4" outlined tile>
-            <slot name="sidebar-start" />
+            <slot name="settings" />
           </v-card>
           <v-card class="pa-4" outlined tile>
-            <slot name="sidebar-end" />
+            <slot name="meta-1" />
           </v-card>
         </v-col>
         <v-col cols="12" :md="6" :lg="8">
@@ -17,25 +17,30 @@
         </v-col>
       </v-row>
       <v-row>
-        <v-col cols="12" :md="6" :lg="4">
-          <v-card class="pa-4" outlined tile>
-            <slot name="meta-1" />
-          </v-card>
-        </v-col>
-        <v-col cols="12" :md="6" :lg="4">
+        <v-col v-if="$slots['meta-2']" cols="12" :md="6" :lg="4">
           <v-card class="pa-4" outlined tile>
             <slot name="meta-2" />
           </v-card>
         </v-col>
-        <v-col cols="12" :md="6" :lg="4">
+        <v-col v-if="$slots['meta-3']" cols="12" :md="6" :lg="4">
           <v-card class="pa-4" outlined tile>
             <slot name="meta-3" />
+          </v-card>
+        </v-col>
+        <v-col v-if="$slots['meta-4']" cols="12" :md="6" :lg="4">
+          <v-card class="pa-4" outlined tile>
+            <slot name="meta-4" />
           </v-card>
         </v-col>
       </v-row>
     </v-container>
   </div>
 </template>
+
+<!-- empty script tag is needed to be able to use $slots in the template, otherwise throws type error -->
+<script>
+export default {};
+</script>
 
 <style>
 .dashboard-layout {

--- a/src/components/MapboxMap/MapLayers.vue
+++ b/src/components/MapboxMap/MapLayers.vue
@@ -1,0 +1,102 @@
+<template>
+  <v-card
+    class="map-layer"
+    :class="{ 'map-layer--open': showLegend }"
+    elevation="4"
+    :max-height="maxLayersHeight"
+    width="280px"
+    :max-width="maxLayersWidth"
+  >
+    <v-card-title class="map-layer__title subtitle-2" @click="toggleLegend">
+      Layers
+
+      <v-icon
+        class="map-layer__button"
+        :class="{ 'map-layer__button--active': showLegend }"
+      >
+        mdi-chevron-down
+      </v-icon>
+    </v-card-title>
+
+    <v-card-text class="map-layer__content">
+      <slot />
+    </v-card-text>
+  </v-card>
+</template>
+  
+  <script>
+import { mapState } from "vuex";
+
+export default {
+  props: {
+    layers: {
+      type: Array,
+      required: true,
+    },
+    initiallySelectedLayers: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  data: () => ({
+    maxLayersHeight: "calc(100vh - 106px)", // subtracts toolbar, margin and padding.
+    maxLayersWidth: "calc(100vw - 32px)", // subtracts padding.
+    selectedLegend: null,
+    showLegend: false,
+  }),
+  computed: mapState(["mangroveLayers", "administrativeBoundariesLayers"]),
+  methods: {
+    toggleLegend() {
+      this.showLegend = !this.showLegend;
+    },
+  },
+};
+</script>
+  
+  <style>
+.map-layer.v-card {
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: absolute;
+  left: 52px;
+  bottom: 24px;
+  transform: translateY(calc(100% - 48px + 24px));
+  transition: transform 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  z-index: 2;
+}
+
+.map-layer--open.v-card {
+  transform: translateY(0%);
+}
+
+.map-layer__button {
+  transform: rotate(-180deg);
+  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.5, 1);
+}
+
+.map-layer__button--active {
+  transform: rotate(0deg);
+}
+
+.map-layer__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.map-layer__content.v-card__text {
+  padding-top: 4px;
+  overflow-y: auto;
+}
+
+.map-layer__image {
+  height: auto;
+  max-width: 100%;
+  width: auto;
+}
+</style>
+  

--- a/src/components/MapboxMap/MapLegend.vue
+++ b/src/components/MapboxMap/MapLegend.vue
@@ -4,7 +4,7 @@
     :class="{ 'map-legend--open': showLegend }"
     elevation="4"
     :max-height="maxLegendHeight"
-    width="360"
+    width="280px"
     :max-width="maxLegendWidth"
     v-if="mangroveLayers.length > 0"
   >

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,22 +1,24 @@
 <template>
   <dashboard-layout>
-    <template slot="sidebar-start">
+    <template slot="settings">
       <h2 class="text-h6 mb-4">Area</h2>
 
       <area-select />
     </template>
     <template slot="sidebar-end">
       <h2 class="text-h6 mb-4">Layers</h2>
-
-      <layers-list
-        :layers="layers"
-        :initiallySelectedLayers="mangroveLayers"
-        @select-layers="setMangroveLayers"
-      />
     </template>
 
     <template slot="main">
-      <app-map />
+      <app-map>
+        <template slot="layers-panel">
+          <layers-list
+            :layers="layers"
+            :initiallySelectedLayers="mangroveLayers"
+            @select-layers="setMangroveLayers"
+          />
+        </template>
+      </app-map>
     </template>
 
     <template slot="meta-1">


### PR DESCRIPTION
At the request of Gerrit, we make the layer list collapsible, so we can make important charts more prominent:

<img width="920" alt="image" src="https://user-images.githubusercontent.com/11621275/228825345-687d6d17-ece5-416a-bdeb-7a469df277ce.png">

<img width="920" alt="image" src="https://user-images.githubusercontent.com/11621275/228825412-d2c1cb83-0039-4451-871c-3b5203cc64ae.png">

