### PR TITLE
Remove administrative boundaries layer when selecting the country layer

### DIFF
--- a/src/components/AreaSelect/AreaSelect.vue
+++ b/src/components/AreaSelect/AreaSelect.vue
@@ -85,9 +85,6 @@ export default {
 
       return false;
     },
-    layerIsCountry() {
-      return this.selectedLayer === "country";
-    },
   },
   methods: {
     ...mapActions([
@@ -149,6 +146,8 @@ export default {
       if (this.selectedLayer?.id) {
         this.setAdministrativeBoundariesLayer({ layer: this.selectedLayer });
         this.getFeatures();
+      } else {
+        this.removeAdministrativeBoundariesLayer();
       }
     },
     selectedFeatureName() {


### PR DESCRIPTION
**Bug:**
1. Select "Provinces" on dropdown
1. The provinces are displayed on the map
1. Select "Country" on dropdown
1. The provinces are still displayed on the map

**Fix:** now on step 4 the provinces layer is removed from the map

