### PR TITLE
Generalize the annual progress query

### DIFF
--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -103,7 +103,7 @@ export default {
     selectedFeature(value) {
       this.resetChartData();
 
-      if (value?.properties.name_1 || value?.properties.name_2) {
+      if (value?.properties[this.selectedLayer.propertyName]) {
         this.getSelectedFeatureData(value);
       }
     },
@@ -196,13 +196,9 @@ export default {
       const { data: areaData } = await axios(
         buildFeatureUrl({
           ...this.selectedLayer,
-          layer:
-            this.selectedLayer.name === "Provinces"
-              ? "indonesia:regions_admin1"
-              : "indonesia:regions_admin2",
+          layer: `indonesia:${this.selectedLayer.layer}`,
           filter:
-            this.selectedFeature.properties.name_1 ||
-            this.selectedFeature.properties.name_2,
+            this.selectedFeature.properties[this.selectedLayer.propertyName],
         })
       );
 


### PR DESCRIPTION
To avoid using `name_1` and `name_2` as much as possible