### PR TITLE
Change background map

### DIFF
--- a/src/components/AppMap/AppMap.vue
+++ b/src/components/AppMap/AppMap.vue
@@ -120,4 +120,8 @@ export default {
   height: 100%;
   width: 100%;
 }
+
+.app-map .mapboxgl-ctrl-attrib-inner a {
+  color: #aeaeae;
+}
 </style>

--- a/src/components/AppMap/AppMap.vue
+++ b/src/components/AppMap/AppMap.vue
@@ -3,7 +3,7 @@
     <v-mapbox
       class="app-map__map"
       :access-token="mapConfig.accessToken"
-      map-style="mapbox://styles/siggyf/ckww2c33f0xlf15nujlx41fe2"
+      :map-style="mapConfig.style"
       :center="mapConfig.center"
       :zoom="mapConfig.zoom"
       @mb-created="onMapCreated"
@@ -12,7 +12,6 @@
         v-if="administrativeBoundariesLayer"
         :key="administrativeBoundariesLayer.id"
         :options="administrativeBoundariesLayer"
-        :opacity="0.3"
       />
 
       <v-mapbox-layer
@@ -24,7 +23,12 @@
       <map-draw-control :drawn-feature="selectedFeature" />
 
       <v-mapbox-geocoder />
-      <map-control-fitbounds
+      <map-style-control
+        :initial-style="mapConfig.style"
+        position="bottom-right"
+        @map-style-changed="onMapStyleChanged"
+      />
+      <map-fitbounds-control
         :fitToBounds="fitToBounds"
         position="bottom-right"
       />
@@ -44,21 +48,23 @@
 import { mapState } from "vuex";
 import { bbox } from "@turf/turf";
 import MapLegend from "@/components/MapboxMap/MapLegend.vue";
-import MapControlFitbounds from "@/components/MapboxMap/MapControlFitbounds.vue";
+import MapFitboundsControl from "@/components/MapboxMap/MapFitboundsControl.vue";
+import MapStyleControl from "@/components/MapboxMap/MapStyleControl.vue";
 import MapDrawControl from "@/components/MapboxMap/MapDrawControl.vue";
 
 export default {
   components: {
-    MapControlFitbounds,
+    MapFitboundsControl,
     MapLegend,
     MapDrawControl,
+    MapStyleControl,
   },
 
   data() {
     return {
       mapConfig: {
         accessToken: process.env.VUE_APP_MAPBOX_TOKEN,
-        style: "mapbox://styles/siggyf/ckww2c33f0xlf15nujlx41fe2",
+        style: "mapbox://styles/voorhoede/clh8u52h600wh01pn73ns8zy8",
         center: [118.69, -3.64],
         zoom: 3.5,
         navigationOptions: {
@@ -87,6 +93,9 @@ export default {
     zoomToSelectedFeature() {
       const boundingBox = bbox(this.selectedFeature);
       this.$root.map.fitBounds(boundingBox, { padding: 80 });
+    },
+    onMapStyleChanged(style) {
+      this.mapConfig.styleId = style;
     },
   },
 

--- a/src/components/AppMap/AppMap.vue
+++ b/src/components/AppMap/AppMap.vue
@@ -12,6 +12,7 @@
         v-if="administrativeBoundariesLayer"
         :key="administrativeBoundariesLayer.id"
         :options="administrativeBoundariesLayer"
+        :opacity="0.5"
       />
 
       <v-mapbox-layer

--- a/src/components/AppMap/AppMap.vue
+++ b/src/components/AppMap/AppMap.vue
@@ -27,7 +27,6 @@
       <map-style-control
         :initial-style="mapConfig.style"
         position="bottom-right"
-        @map-style-changed="onMapStyleChanged"
       />
       <map-fitbounds-control
         :fitToBounds="fitToBounds"
@@ -94,9 +93,6 @@ export default {
     zoomToSelectedFeature() {
       const boundingBox = bbox(this.selectedFeature);
       this.$root.map.fitBounds(boundingBox, { padding: 80 });
-    },
-    onMapStyleChanged(style) {
-      this.mapConfig.styleId = style;
     },
   },
 

--- a/src/components/IntroductionDialog/IntroductionDialog.vue
+++ b/src/components/IntroductionDialog/IntroductionDialog.vue
@@ -12,13 +12,7 @@
       </template>
 
       <v-card>
-        <v-toolbar flat>
-          <v-toolbar-title class="text-h5">Introduction</v-toolbar-title>
-          <v-spacer />
-          <v-btn icon>
-            <v-icon> mdi-close </v-icon>
-          </v-btn>
-        </v-toolbar>
+        <v-card-title class="text-h5"> Introduction </v-card-title>
 
         <v-card-text>
           <p>

--- a/src/components/IntroductionDialog/IntroductionDialog.vue
+++ b/src/components/IntroductionDialog/IntroductionDialog.vue
@@ -12,7 +12,13 @@
       </template>
 
       <v-card>
-        <v-card-title class="text-h5"> Introduction </v-card-title>
+        <v-toolbar flat>
+          <v-toolbar-title class="text-h5">Introduction</v-toolbar-title>
+          <v-spacer />
+          <v-btn icon>
+            <v-icon> mdi-close </v-icon>
+          </v-btn>
+        </v-toolbar>
 
         <v-card-text>
           <p>

--- a/src/components/MapboxMap/MapFitboundsControl.vue
+++ b/src/components/MapboxMap/MapFitboundsControl.vue
@@ -53,14 +53,14 @@ export default {
 
     addToMap(map) {
       const { $control } = this.$refs;
-      const control = new MapControlFitbounds($control);
+      const control = new MapFitboundsControl($control);
       map.addControl(control, this.position);
       this.showControl = true;
     },
   },
 };
 
-class MapControlFitbounds {
+class MapFitboundsControl {
   constructor($element) {
     this._container = $element;
   }

--- a/src/components/MapboxMap/MapLayers.vue
+++ b/src/components/MapboxMap/MapLayers.vue
@@ -25,8 +25,6 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
-
 export default {
   data: () => ({
     maxLayersHeight: "calc(100vh - 106px)", // subtracts toolbar, margin and padding.
@@ -34,10 +32,6 @@ export default {
     selectedLegend: null,
     showLegend: false,
   }),
-  computed: mapState("data", [
-    "mangroveLayers",
-    "administrativeBoundariesLayers",
-  ]),
   methods: {
     toggleLegend() {
       this.showLegend = !this.showLegend;

--- a/src/components/MapboxMap/MapStyleControl.vue
+++ b/src/components/MapboxMap/MapStyleControl.vue
@@ -6,7 +6,7 @@
     @click="changeMapStyle"
     v-show="showControl"
   >
-    <v-icon color="black">mdi-map</v-icon>
+    <v-icon color="black">mdi-layers-triple</v-icon>
   </button>
 </template>
 

--- a/src/components/MapboxMap/MapStyleControl.vue
+++ b/src/components/MapboxMap/MapStyleControl.vue
@@ -1,0 +1,125 @@
+<template>
+  <button
+    class="map-style-control mapboxgl-ctrl"
+    title="Change map style"
+    ref="$control"
+    @click="changeMapStyle"
+    v-show="showControl"
+  >
+    <v-icon color="black">mdi-map</v-icon>
+  </button>
+</template>
+
+<script>
+import { mapState, mapActions } from "vuex";
+
+export default {
+  inject: ["getMap"],
+
+  props: {
+    initialStyle: {
+      type: String,
+      required: true,
+    },
+    position: {
+      type: String,
+      required: false,
+    },
+  },
+
+  data: () => ({
+    showControl: false,
+    currentStyle: "",
+    styles: {
+      dark: "mapbox://styles/voorhoede/clh8vjw3600x501pg1dzk7vw3",
+      light: "mapbox://styles/voorhoede/clh8u52h600wh01pn73ns8zy8",
+    },
+  }),
+
+  mounted() {
+    const map = this.getMap();
+    // If we are already loaded
+    if (map && map.loaded()) {
+      this.addToMap(map);
+    }
+    this.currentStyle = this.initialStyle;
+  },
+
+  computed: mapState("data", [
+    "mangroveLayers",
+    "administrativeBoundariesLayer",
+  ]),
+
+  methods: {
+    ...mapActions("data", [
+      "setMangroveLayers",
+      "setAdministrativeBoundariesLayer",
+    ]),
+
+    deferredMountedTo(map) {
+      this.addToMap(map);
+    },
+
+    addToMap(map) {
+      const { $control } = this.$refs;
+      const control = new MapStyleControl($control);
+      map.addControl(control, this.position);
+      this.showControl = true;
+    },
+
+    changeMapStyle() {
+      const map = this.getMap();
+
+      this.currentStyle =
+        this.currentStyle === this.styles.light
+          ? this.styles.dark
+          : this.styles.light;
+
+      map.setStyle(this.currentStyle);
+
+      // Changing the style removes all layers and sources
+      // We need to re-add them
+      // https://github.com/mapbox/mapbox-gl-js/issues/4006
+      map.on("style.load", () => {
+        this.setMangroveLayers({ layers: this.mangroveLayers });
+        if (this.administrativeBoundariesLayer) {
+          this.setAdministrativeBoundariesLayer({
+            layer: this.administrativeBoundariesLayer,
+          });
+        }
+      });
+    },
+  },
+};
+
+class MapStyleControl {
+  constructor($element) {
+    this._container = $element;
+  }
+
+  onAdd() {
+    return this._container;
+  }
+
+  onRemove() {
+    this._container.parentNode.removeChild(this._container);
+  }
+}
+</script>
+
+<style>
+.map-style-control {
+  width: 30px;
+  height: 30px;
+  padding: 3px;
+  background-color: white;
+  outline: 0;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+}
+
+.map-style-control:hover {
+  background-color: #f2f2f2; /* #ffffff + rgba(0, 0, 0, 0.05) */
+}
+</style>


### PR DESCRIPTION
Ticket: https://issuetracker.deltares.nl/browse/IDPMR-21

Changes:
- Create light and dark styles under the shared@voorhoede.nl account on https://studio.mapbox.com/
- Update env variable VUE_APP_MAPBOX_TOKEN
- Renamed `MapControlFitbounds` to `MapFitboundsControl` (for consistency, since we have `MapDrawControl`)
- Add button to map to switch styles
- Reload layers after styles have changed


The button:
<img width="185" alt="image" src="https://user-images.githubusercontent.com/15196342/236194754-749ddf87-c05a-44d7-8c29-6fa039df8852.png">
