### PR TITLE
Fix: remove unnecessary trigger for updateLayers

### DIFF
--- a/src/components/LayersList/LayersList.vue
+++ b/src/components/LayersList/LayersList.vue
@@ -1,10 +1,5 @@
 <template>
-  <draggable
-    tag="ul"
-    v-model="sortedLayers"
-    class="layers-list"
-    @end="updateLayers"
-  >
+  <draggable tag="ul" v-model="sortedLayers" class="layers-list">
     <li class="layers-list__item" v-for="layer in sortedLayers" :key="layer.id">
       <layer-card
         :layer="layer"


### PR DESCRIPTION
Fixes this error:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/15196342/236189936-8f60a922-56c0-489f-861c-5e11792588dc.png">

We are watching `sortedLayers` so it was being called twice anyway, one with a list of layers and other time with an event.