### PR TITLE
Fix: remove slider functionality from tabs

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -26,7 +26,7 @@
     <authentication />
 
     <template v-slot:extension v-if="$vuetify.breakpoint.mobile">
-      <v-tabs class="app-header__tabs mr-4" v-model="currentTab" centered>
+      <v-tabs class="app-header__tabs" v-model="currentTab" centered>
         <v-tab v-for="tab in tabs" :key="tab.id" :to="tab.slug" exact-path>
           {{ tab.title }}
         </v-tab>

--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -86,4 +86,7 @@ export default {
 .app-header__tabs.v-tabs {
   width: auto;
 }
+.v-tabs-bar__content {
+  width: 100%;
+}
 </style>


### PR DESCRIPTION
Before:
<img width="459" alt="image" src="https://user-images.githubusercontent.com/15196342/236192169-67c5239b-500d-4b3c-a15b-3163690d8016.png">

After:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/15196342/236192109-ede17299-e504-4b2e-ae03-101dc94249cb.png">

For this demo with only 2 tabs it's better if the names are fully visible, instead of scrollable on mobile.