### PR TITLE
Only drag using the icon not the whole card

### DIFF
--- a/src/components/LayersList/LayersList.vue
+++ b/src/components/LayersList/LayersList.vue
@@ -1,5 +1,10 @@
 <template>
-  <draggable tag="ul" v-model="sortedLayers" class="layers-list">
+  <draggable
+    tag="ul"
+    v-model="sortedLayers"
+    class="layers-list"
+    :options="{ handle: '.layer-card__drag-icon' }"
+  >
     <li class="layers-list__item" v-for="layer in sortedLayers" :key="layer.id">
       <layer-card
         :layer="layer"


### PR DESCRIPTION
**Before:** on mobile it the show and info buttons didn't always work because they were intersected by the dragging logic
**After:** dragging is only possible using the when pressing on the dots icons (the cursor changes to a cross of arrows), this way the action buttons always work on mobile