### PR TITLE
Update vue2mapbox-gl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "vue": "2.6",
         "vue-echarts": "^6.5.4",
         "vue-router": "^3.6.5",
-        "vue2mapbox-gl": "^0.13.1",
+        "vue2mapbox-gl": "^0.15.0",
         "vuedraggable": "^2.24.3",
         "vuetify": "^2.6.14",
         "vuex": "^3.6.2"
@@ -2013,13 +2013,14 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-geocoder": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-geocoder/-/mapbox-gl-geocoder-4.7.4.tgz",
-      "integrity": "sha512-9PIilTgqnoSCVtzJ1MnE4f1siWIpC9GO5MPaKTOspb7hXIvcgFOp44PSWP+WlDTHoEze3Dz3WQuppti6TVWjyg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-geocoder/-/mapbox-gl-geocoder-5.0.1.tgz",
+      "integrity": "sha512-/OUL42eh4OBaIerhcwCpa27oD+u4a2xN8V7vEdsglwd8lCplFAxJCdwT9Kprli1TH5mTYsXyONmh03FwoWBWfA==",
       "dependencies": {
-        "@mapbox/mapbox-sdk": "^0.13.2",
+        "@mapbox/mapbox-sdk": "^0.13.3",
+        "events": "^3.3.0",
         "lodash.debounce": "^4.0.6",
-        "nanoid": "^2.0.1",
+        "nanoid": "^3.1.31",
         "subtag": "^0.5.0",
         "suggestions": "^1.6.0",
         "xtend": "^4.0.1"
@@ -2030,11 +2031,6 @@
       "peerDependencies": {
         "mapbox-gl": ">= 0.47.0 < 3.0.0"
       }
-    },
-    "node_modules/@mapbox/mapbox-gl-geocoder/node_modules/nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
     },
     "node_modules/@mapbox/mapbox-gl-supported": {
       "version": "2.0.1",
@@ -2074,17 +2070,14 @@
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@mapbox/polyline": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/polyline/-/polyline-1.1.1.tgz",
-      "integrity": "sha512-z9Sl7NYzsEIrAza658H92mc0OvpBjQwjp7Snv4xREKhsCMat7m1IKdWJMjQ5opiPYa0veMf7kCaSd1yx55AhmQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/polyline/-/polyline-1.2.0.tgz",
+      "integrity": "sha512-sIIi9clVZiTmXYqbXpSAoG+ZLsvQn7j9FJLqiNOG85KnXN8tz11MEhuW2M7NDEDIKi4hIMaSI1CKwH8oLuVxPQ==",
       "dependencies": {
         "meow": "^6.1.1"
       },
       "bin": {
         "polyline": "bin/polyline.bin.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@mapbox/tiny-sdf": {
@@ -5549,9 +5542,9 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -7656,7 +7649,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -9179,9 +9171,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "peer": true
     },
     "node_modules/keyv": {
@@ -9614,9 +9606,9 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.13.0.tgz",
-      "integrity": "sha512-G8pU1/I9HC7xNbhKPKFtRkdUDkWJBNbYPMeRjBig3lPaYtvHPIaFmXMR6BDyZ/gnwodElrwMZGdGsoH8kecX8w==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.15.0.tgz",
+      "integrity": "sha512-fjv+aYrd5TIHiL7wRa+W7KjtUqKWziJMZUkK5hm8TvJ3OLeNPx4NmW/DgfYhd/jHej8wWL+QJBDbdMMAKvNC0A==",
       "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -9632,12 +9624,13 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",
         "grid-index": "^1.1.0",
+        "kdbush": "^4.0.1",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^2.0.0",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.1.5",
+        "supercluster": "^8.0.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.3"
       }
@@ -10008,7 +10001,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -11715,11 +11707,6 @@
       "resolved": "https://registry.npmjs.org/resize-detector/-/resize-detector-0.3.0.tgz",
       "integrity": "sha512-R/tCuvuOHQ8o2boRP6vgx8hXCCy87H1eY9V5imBYeVNyNVpuL9ciReSccLj2gDcax9+2weXy3bc8Vv+NRXeEvQ=="
     },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -12475,12 +12462,12 @@
       }
     },
     "node_modules/supercluster": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "peer": true,
       "dependencies": {
-        "kdbush": "^3.0.0"
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supports-color": {
@@ -13313,18 +13300,17 @@
       "dev": true
     },
     "node_modules/vue2mapbox-gl": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/vue2mapbox-gl/-/vue2mapbox-gl-0.13.1.tgz",
-      "integrity": "sha512-KFLphshkOrZwAZW0i6Rs4a+E2+tAOVgQDFit4ThF73gk0IdTL/AEu61pUODGR0Tj9CrUMTjYBzXP/jxcstt6fw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/vue2mapbox-gl/-/vue2mapbox-gl-0.15.0.tgz",
+      "integrity": "sha512-UcqRL/EO8Jg0B+xz0uAarlZr8hOjfWcs90UVJ/igoWtwXgBKl4TUQsXL0N4hGGjBpwPsnB0vnN435wpkkx26hA==",
       "dependencies": {
-        "@mapbox/mapbox-gl-geocoder": "^4.4.1",
-        "resize-observer-polyfill": "^1.5.1"
+        "@mapbox/mapbox-gl-geocoder": "^5.0.1"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "mapbox-gl": ">=1.0.0",
+        "mapbox-gl": ">=2.0.0",
         "vue": ">=2.6.10"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "vue": "2.6",
     "vue-echarts": "^6.5.4",
     "vue-router": "^3.6.5",
-    "vue2mapbox-gl": "^0.13.1",
+    "vue2mapbox-gl": "^0.15.0",
     "vuedraggable": "^2.24.3",
     "vuetify": "^2.6.14",
     "vuex": "^3.6.2"

--- a/src/components/AppMap/AppMap.vue
+++ b/src/components/AppMap/AppMap.vue
@@ -25,7 +25,8 @@
 
       <v-mapbox-geocoder />
       <map-style-control
-        :initial-style="mapConfig.style"
+        :current-style="mapConfig.style"
+        @update-style="updateStyle"
         position="bottom-right"
         class="app-map__control"
       />
@@ -66,7 +67,7 @@ export default {
     return {
       mapConfig: {
         accessToken: process.env.VUE_APP_MAPBOX_TOKEN,
-        style: "mapbox://styles/voorhoede/clh8u52h600wh01pn73ns8zy8",
+        style: "mapbox://styles/mapbox/light-v11",
         center: [118.69, -3.64],
         zoom: 3.5,
         navigationOptions: {
@@ -95,6 +96,9 @@ export default {
     zoomToSelectedFeature() {
       const boundingBox = bbox(this.selectedFeature);
       this.$root.map.fitBounds(boundingBox, { padding: 80 });
+    },
+    updateStyle(style) {
+      this.mapConfig.style = style;
     },
   },
 

--- a/src/components/MapboxMap/MapStyleControl.vue
+++ b/src/components/MapboxMap/MapStyleControl.vue
@@ -17,7 +17,7 @@ export default {
   inject: ["getMap"],
 
   props: {
-    initialStyle: {
+    currentStyle: {
       type: String,
       required: true,
     },
@@ -29,10 +29,9 @@ export default {
 
   data: () => ({
     showControl: false,
-    currentStyle: "",
     styles: {
-      dark: 'mapbox://styles/mapbox/dark-v11',
-      light: 'mapbox://styles/mapbox/light-v11',
+      dark: "mapbox://styles/mapbox/dark-v11",
+      light: "mapbox://styles/mapbox/light-v11",
     },
   }),
 
@@ -42,7 +41,6 @@ export default {
     if (map && map.loaded()) {
       this.addToMap(map);
     }
-    this.currentStyle = this.initialStyle;
   },
 
   computed: mapState("data", [
@@ -68,26 +66,11 @@ export default {
     },
 
     changeMapStyle() {
-      const map = this.getMap();
-
-      this.currentStyle =
+      const newStyle =
         this.currentStyle === this.styles.light
           ? this.styles.dark
           : this.styles.light;
-
-      map.setStyle(this.currentStyle);
-
-      // Changing the style removes all layers and sources
-      // We need to re-add them
-      // https://github.com/mapbox/mapbox-gl-js/issues/4006
-      map.on("style.load", () => {
-        this.setMangroveLayers({ layers: this.mangroveLayers });
-        if (this.administrativeBoundariesLayer) {
-          this.setAdministrativeBoundariesLayer({
-            layer: this.administrativeBoundariesLayer,
-          });
-        }
-      });
+      this.$emit("update-style", newStyle);
     },
   },
 };


### PR DESCRIPTION
Changes:
- Update to latest version of `vue2mapbox-gl` 
- Remove workaround to reload layers after style change (now it can be done using `vue2mapbox-gl`)